### PR TITLE
Update qwilEmbed.js-meta.xml targets

### DIFF
--- a/force-app/main/default/lwc/qwilEmbed/qwilEmbed.js-meta.xml
+++ b/force-app/main/default/lwc/qwilEmbed/qwilEmbed.js-meta.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>59.0</apiVersion>
-    <isExposed>false</isExposed>
+     <apiVersion>61.0</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__RecordPage</target>
+        <target>lightning__AppPage</target>
+        <target>lightning__HomePage</target>
+        <target>lightning__Tab</target>
+        <target>lightningCommunity__Page</target>
+        <target>lightningCommunity__Default</target>
+    </targets>
 </LightningComponentBundle>


### PR DESCRIPTION
Updating js-meta.xml's targets to allow embed LWC to be placed anywhere within the lightning experience without the Aura wrapper if needed.